### PR TITLE
Fix exception when parsing a file which worked in 0.12

### DIFF
--- a/lib/hexapdf/type/page.rb
+++ b/lib/hexapdf/type/page.rb
@@ -304,6 +304,7 @@ module HexaPDF
       def contents
         Array(self[:Contents]).each_with_object("".b) do |content_stream, content|
           content << " " unless content.empty?
+          content_stream = document.object(content_stream) if content_stream.is_a?(HexaPDF::Reference)
           content << content_stream.stream
         end
       end


### PR DESCRIPTION
Started getting an exception after updating to `0.13`: 

```
   NoMethodError:
       undefined method `stream' for #<HexaPDF::Reference [22, 0]>
     # .../hexapdf-0.13.0/lib/hexapdf/type/page.rb:308:in `block in contents'
     # .../hexapdf-0.13.0/lib/hexapdf/type/page.rb:305:in `each'
     # .../hexapdf-0.13.0/lib/hexapdf/type/page.rb:305:in `each_with_object'
     # .../hexapdf-0.13.0/lib/hexapdf/type/page.rb:305:in `contents'
     # .../hexapdf-0.13.0/lib/hexapdf/type/page.rb:455:in `to_form_xobject'
     # .../hexapdf-0.13.0/lib/hexapdf/type/page_tree_node.rb:226:in `block in each_page'
     # .../hexapdf-0.13.0/lib/hexapdf/pdf_array.rb:180:in `block in each'
     # .../hexapdf-0.13.0/lib/hexapdf/pdf_array.rb:180:in `each_index'
     # .../hexapdf-0.13.0/lib/hexapdf/pdf_array.rb:180:in `each'
     # .../hexapdf-0.13.0/lib/hexapdf/type/page_tree_node.rb:224:in `each_page'
     # .../hexapdf-0.13.0/lib/hexapdf/document/pages.rb:131:in `each'
```

This was able to fix my problem.