### PR TITLE
Add space character to MalformedPDFError message

### DIFF
--- a/lib/hexapdf/error.rb
+++ b/lib/hexapdf/error.rb
@@ -54,7 +54,7 @@ module HexaPDF
     end
 
     def message # :nodoc:
-      "PDF malformed#{pos ? "around position #{pos}" : ''}: #{super}"
+      "PDF malformed#{pos ? " around position #{pos}" : ''}: #{super}"
     end
 
   end


### PR DESCRIPTION
Prior to this change, introduced in v0.14.4, `HexaPDF::MalformedPDFError#message` with a non-`nil` `pos` argument rendered like:

```
PDF malformedaround position 0: ...
```

This PR adds a space between `malformed` and `around` for even gooderer English.

Thanks for working on hexapdf!