### PR TITLE
Fixed infinite loop due unclosed array/dictionary in corrupted PDFs

### DIFF
--- a/lib/hexapdf/tokenizer.rb
+++ b/lib/hexapdf/tokenizer.rb
@@ -384,6 +384,9 @@ module HexaPDF
       while true
         obj = next_object(allow_end_array_token: true)
         break if obj.equal?(TOKEN_ARRAY_END)
+        if obj.equal?(NO_MORE_TOKENS)
+          raise HexaPDF::MalformedPDFError.new("Reached end of file while parsing array", pos: pos)
+        end
         result << obj
       end
       result
@@ -401,6 +404,9 @@ module HexaPDF
         # throw an error with #next_object.
         key = next_token
         break if key.equal?(TOKEN_DICT_END)
+        if key.equal?(NO_MORE_TOKENS)
+          raise HexaPDF::MalformedPDFError.new("Reached end of file while parsing dictionary", pos: pos)
+        end
         unless key.kind_of?(Symbol)
           raise HexaPDF::MalformedPDFError.new("Dictionary keys must be PDF name objects", pos: pos)
         end

--- a/test/hexapdf/common_tokenizer_tests.rb
+++ b/test/hexapdf/common_tokenizer_tests.rb
@@ -143,6 +143,16 @@ module CommonTokenizerTests
     assert_equal({Name: 5}, @tokenizer.next_object)
   end
 
+  it "next_token: fails on a array without closing bracket" do
+    create_tokenizer("[1 2")
+    assert_raises(HexaPDF::MalformedPDFError) { @tokenizer.next_object }
+  end
+
+  it "next_token: fails on a dict without closing bracket" do
+    create_tokenizer("<</Name /5")
+    assert_raises(HexaPDF::MalformedPDFError) { @tokenizer.next_object }
+  end
+
   it "next_object: allows keywords if the corresponding option is set" do
     create_tokenizer("name")
     obj = @tokenizer.next_object(allow_keyword: true)


### PR DESCRIPTION
**Issue**
When a PDF file has unclosed array (seems like dictionary too) tokenizer stucks in an infinite loop.

**Solution**
I have added raise of `MalformedPDFError` when tokenizer gets `NO_MORE_TOKENS`. Not sure if it is right solution but at least all test are green and there is no infinite loop.