### PR TITLE
Use Safe Navigation on XObject Resources in prune_page_resources

### DIFF
--- a/lib/hexapdf/task/optimize.rb
+++ b/lib/hexapdf/task/optimize.rb
@@ -254,7 +254,7 @@ module HexaPDF
 
         doc.pages.each do |page|
           xobjects = page.resources[:XObject]
-          xobjects.each do |key, obj|
+          xobjects&.each do |key, obj|
             next if used_refs[obj]
             xobjects.delete(key)
           end

--- a/test/hexapdf/task/test_optimize.rb
+++ b/test/hexapdf/task/test_optimize.rb
@@ -174,6 +174,8 @@ describe HexaPDF::Task::Optimize do
         page2.resources[:XObject][:used_on2] = page1.resources[:XObject][:used_on_page2]
         page2.resources[:XObject][:also_unused] = page1.resources[:XObject][:unused]
         page2.contents = "/used_on2 Do"
+        page3 = @doc.pages.add
+        page3.contents = "Page without an XObject reference"
 
         @doc.task(:optimize, prune_page_resources: true, compress_pages: compress_pages)
 
@@ -182,6 +184,7 @@ describe HexaPDF::Task::Optimize do
         refute(page1.resources[:XObject].key?(:unused))
         assert(page2.resources[:XObject].key?(:used_on2))
         refute(page2.resources[:XObject].key?(:also_unused))
+        assert_nil(page3.resources[:XObject])
       end
     end
   end


### PR DESCRIPTION
I was testing the PDF optimization options and hit an exception.  Here's an example:

```ruby
require 'hexapdf'

# Write "Hello World" PDF
doc = HexaPDF::Document.new
canvas = doc.pages.add.canvas
canvas.font('Helvetica', size: 100)
canvas.text("Hello World!", at: [20, 400])
doc.write("hello_world.pdf", optimize: true)

# Attempt to Optimize
HexaPDF::Document.open("hello_world.pdf") do |doc|
  doc.task(:optimize, prune_page_resources: true)
  doc.write('optimizing.pdf')
end
```

This crashed on:

```
lib/hexapdf/task/optimize.rb:257:in `block in prune_page_resources'
NoMethodError (undefined method `each' for nil:NilClass)
```

I saw that other areas use `&.` like [HexaPDF::Type::Font](https://github.com/gettalong/hexapdf/blob/master/lib/hexapdf/cli/fonts.rb#L128):

```ruby
# lib/hexapdf/cli/fonts.rb
page.resources[:XObject]&.each do |_, xobj|
```

So that's the update I've made here.