### PR TITLE
Changes to the README and the .rubocop.yml to reflect the updated minimum Ruby version of 2.5

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,7 @@ AllCops:
     - test/**/*.rb
   Exclude:
     - '[^blt]*/**/*'
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5
 
 
 Layout/LineLength:

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ with example graphics and PDF files and tightly integrated into the rest of the 
 ## Requirements and Installation
 
 Since HexaPDF is written in Ruby, a working Ruby installation is needed - see the
-[official installation documentation][rbinstall] for details. Note that you need Ruby version 2.4 or
+[official installation documentation][rbinstall] for details. Note that you need Ruby version 2.5 or
 higher as prior versions are not supported!
 
 Apart from Ruby itself the HexaPDF library has only one external dependency `geom2d` which is


### PR DESCRIPTION
This change also gets Rubocop running again, as a Ruby target version of 2.4 is no longer supported.

A couple of followup questions I had after making this PR:

1. Is there any interest in setting up GitHub Actions for CI?  If so, that's relatively straightforward and I'd be happy to submit a PR.
2. Rubocop is not passing.  Is there interest in a PR to address or suppress these lints?