### PR TITLE
Issue 265: Fix typo in CLI fonts command

### DIFF
--- a/lib/hexapdf/cli/fonts.rb
+++ b/lib/hexapdf/cli/fonts.rb
@@ -127,7 +127,7 @@ module HexaPDF
           page.resources[:Font]&.each(&font_proc)
           page.resources[:XObject]&.each do |_, xobj|
             next unless xobj[:Subtype] == :Form
-            xobj.ressources[:Font]&.each(&font_proc)
+            xobj.resources[:Font]&.each(&font_proc)
           end
           page.each_annotation do |annotation|
             appearance = annotation.appearance


### PR DESCRIPTION
See https://github.com/gettalong/hexapdf/issues/265