### PR TITLE
regex fix

### DIFF
--- a/lib/hexapdf/font/encoding/glyph_list.rb
+++ b/lib/hexapdf/font/encoding/glyph_list.rb
@@ -89,7 +89,7 @@ module HexaPDF
             @standard_name_to_uni[name]
           else
             name = name.to_s
-            if name =~ /\Auni([0-9A-F]{4})\Z/ || name =~ /\Au([0-9A-f]{4,6})\Z/
+            if name =~ /\Auni(\h{4})\Z/ || name =~ /\Au(\h{4,6})\Z/
               +'' << $1.hex
             end
           end


### PR DESCRIPTION
Hey there!  I saw a minor security vulnerability with a regex in this library.  In trying to match a hexidecimal character, the regex does `/A-f/` - note that A-f is a much larger range than A-F and includes some fun character (see `('A'...'f').to_a`).  The simpliest fix is changing the regex to be

```ruby
name =~ /\Au([0-9A-f]{4,6})\Z/
```

but then I discovered that Ruby regex has it's own shorthand for [matching hex characters](https://ruby-doc.org/core-3.0.0/Regexp.html#class-Regexp-label-Character+Classes) `\h`, which seems even better.  are you open to fixing this regex?