### PR TITLE
Reduce string memory usage on Tokenizer#prepare_string_scanner

### DIFF
--- a/lib/hexapdf/tokenizer.rb
+++ b/lib/hexapdf/tokenizer.rb
@@ -82,6 +82,7 @@ module HexaPDF
     # correctable situations are only raised if the return value of calling the object is +true+.
     def initialize(io, on_correctable_error: nil)
       @io = io
+      @io_chunk = String.new(''.b)
       @ss = StringScanner.new(''.b)
       @original_pos = -1
       @on_correctable_error = on_correctable_error || proc { false }
@@ -439,9 +440,9 @@ module HexaPDF
       @io.seek(@next_read_pos)
       return false if @io.eof?
 
-      @ss << @io.read(8192)
+      @ss << @io.read(8192, @io_chunk)
       if @ss.pos > 8192 && @ss.string.length > 16384
-        @ss.string.slice!(0, 8192)
+        @ss.string.replace(@ss.string.byteslice(8192..-1))
         @ss.pos -= 8192
         @original_pos += 8192
       end


### PR DESCRIPTION
I was able to reduce the memory usage by 5% on `Tokenizer#prepare_string_scanner` method and reduce some `String` object allocations as well. Here is the script I used to benchmark this change with `memory_profiler` gem:

```ruby
doc = HexaPDF::Document.new io: File.open(File.expand_path("./big_pdf.pdf"))
doc.pages.each do |page|
  canvas = page.canvas(type: :overlay)
  canvas.font("Helvetica", size: 8, variant: :italic)
  canvas.text("Something", at: [10, 10])
end
doc.write "test.pdf", incremental: true, validate: false
```
Before:
```
Total allocated: 104.17 MB (1025017 objects)
Total retained:  18.14 MB (119724 objects)
```

After:
```
Total allocated: 99.69 MB (1024478 objects)
Total retained:  18.15 MB (119726 objects)
```