### PR TITLE
Validate absence of superfluous entries in trailer dictionary

### DIFF
--- a/lib/hexapdf/type/trailer.rb
+++ b/lib/hexapdf/type/trailer.rb
@@ -118,6 +118,13 @@ module HexaPDF
                                !document.security_handler.encryption_key_valid?)
           yield("Encryption key doesn't match encryption dictionary", false)
         end
+
+        valid_keys = [:Size, :Prev, :Root, :Encrypt, :Info, :ID, :XRefStm]
+        superfluous_keys = value.keys - valid_keys
+        unless superfluous_keys.empty?
+          yield("Trailer may only contain /Size, /Prev, /Root, /Encrypt, /Info, /ID & /XRefStm keys", true)
+          value.select! {|k| valid_keys.include?(k) }
+        end
       end
 
     end

--- a/test/hexapdf/type/test_trailer.rb
+++ b/test/hexapdf/type/test_trailer.rb
@@ -112,5 +112,15 @@ describe HexaPDF::Type::Trailer do
       @obj[:Encrypt] = {}
       refute(@obj.validate)
     end
+
+    it "validates and corrects superfluous dictionary entries" do
+      @obj.set_random_id
+      @obj[:Type] = :SomeOtherObject
+      @obj.validate do |msg, correctable|
+        assert(correctable)
+        assert_match(/Trailer may only contain/, msg)
+      end
+      assert_nil(@obj[:Type])
+    end
   end
 end


### PR DESCRIPTION
See #326 for context.

Validate the absence of non-standard trailer dictionary keys (i.e. those listed in ISO 32000-2 7.5.5.). If desired, this could also be extended to allow second class entries as per Annex E, although I'm not sure how prevalent their use in trailer dictionaries is, or if their use causes issues with some readers.