### PR TITLE
Pass arguments on write_to_string

### DIFF
--- a/lib/hexapdf/document.rb
+++ b/lib/hexapdf/document.rb
@@ -823,7 +823,7 @@ module HexaPDF
     # See #write for further information and details on the available arguments.
     def write_to_string(**args)
       io = StringIO.new(''.b)
-      write(io)
+      write(io, **args)
       io.string
     end
 


### PR DESCRIPTION
According to the description, the same arguments are used as write(). Accordingly, they must also be passed on.