### PR TITLE
Avoid SymbolEncoding error when cloning and saving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,15 @@
+## 1.4.1 - 2025-08-21
+
+### Proposed
+
+* [HexaPDF::Type::Annotations::Polygon] for polygon annotations as well as
+  [HexaPDF::Document::Annotations#create_polygon]
+
 ## 1.4.0 - 2025-08-03
 
 ### Added
 
-* [HexaPDF::Type::Annotations::Polygon] for polygon annotations as well as
-  [HexaPDF::Document::Annotations#create_polygon]
-* [HexaPDF::Type::Annotations::Polyline] for polyline annotations as well as
-  [HexaPDF::Document::Annotations#create_polyline]
-* [HexaPDF::Layout::ContainerBox#splitable] for specifying whether the container
-  box may be split
-* [HexaPDF::Layout::Style::Layers#layers] for retrieving the list of defined
-  layers
-* [HexaPDF::Document::Layout#resolve_font] for resolving the font style property
-* [HexaPDF::Type::Measure] for representing the measure dictionary
-* [HexaPDF::Layout::Box::FitResult#failure!] for setting the result status to
-  failure
+* [HexaPDF::Type::FontType1] support SymbolEncoding??
 
 ### Changed
 

--- a/lib/hexapdf/type/font_type1.rb
+++ b/lib/hexapdf/type/font_type1.rb
@@ -170,7 +170,7 @@ module HexaPDF
         end
       end
 
-      PREDEFINED_ENCODING = [:MacRomanEncoding, :MacExpertEncoding, :WinAnsiEncoding] #:nodoc:
+      PREDEFINED_ENCODING = [:MacRomanEncoding, :MacExpertEncoding, :SymbolEncoding, :WinAnsiEncoding] #:nodoc:
 
       # Validates the Type1 font dictionary.
       def perform_validation

--- a/lib/hexapdf/version.rb
+++ b/lib/hexapdf/version.rb
@@ -37,6 +37,6 @@
 module HexaPDF
 
   # The version of HexaPDF.
-  VERSION = '1.4.0'
+  VERSION = '1.4.1'
 
 end


### PR DESCRIPTION
We're not sure if this is the correct fix, but sometimes when copying/importing pages between documents it creates a validation error as shown below. The quick fix is to allow SymbolEncoding as a valid Font encoding, which seems to work fine.

This issue only happens with some PDFs, we're assuming those that contain symbols.

```
> doc = HexaPDF::Document.open('/path/to/original.pdf')
=> <HexaPDF::Document:13904>
> new_doc = HexaPDF::Document.new
=> <HexaPDF::Document:13864>
> new_doc.pages << new_doc.import(doc.pages[1])
=> #<HexaPDF::Document::Pages:0x000000016119f340 @document=<HexaPDF::Document:13864>>
> new_doc.pages.size
=> 1
> new_doc.validate
=> false
> new_doc2.write('/path/to/test.pdf')
HexaPDF::Error: Validation error for (371,0): The /Encoding value 'SymbolEncoding' is invalid (HexaPDF::Error)
```