### PR TITLE
Force use document version regardless of catalog's entries

### DIFF
--- a/lib/hexapdf/document.rb
+++ b/lib/hexapdf/document.rb
@@ -611,6 +611,9 @@ module HexaPDF
     # See: PDF2.0 s7.2.2
     def version
       catalog_version = (catalog[:Version] || '1.0').to_s
+
+      return @version if use_document_version
+      
       (@version < catalog_version ? catalog_version : @version)
     end
 
@@ -621,6 +624,16 @@ module HexaPDF
     def version=(value)
       raise ArgumentError, "PDF version must follow format M.N" unless value.to_s.match?(/\A\d\.\d\z/)
       @version = value.to_s
+    end
+
+    def use_document_version
+      @use_document_version
+    end
+
+    # The are certain cases in which we want to use the document version regardless
+    # of catalog's entries.
+    def use_document_version=(value)
+      @use_document_version = value
     end
 
     # Returns +true+ if the document is encrypted.

--- a/test/hexapdf/test_document.rb
+++ b/test/hexapdf/test_document.rb
@@ -455,6 +455,14 @@ describe HexaPDF::Document do
       assert_equal('1.4', @doc.version)
     end
 
+    it "allows setting forcing a lower version than from catalog's version entry" do
+      @doc.version = '1.7'
+      @doc.use_document_version = true
+
+      (@doc.trailer[:Root] ||= {})[:Version] = '2.0'
+      assert_equal('1.7', @doc.version)
+    end
+
     it "fails setting a version with an invalid format" do
       assert_raises(ArgumentError) { @doc.version = 'bla' }
     end


### PR DESCRIPTION
There are certain cases, like Zugferd, in which we want to use a specific version. In this case 1.7.
However, when we use certain features of HexaPDF the version is automatically bumped to 2.0 .

Introduce a new attribute `use_document_version` which returns the document version regardless of 
catalog's entries.