### PR TITLE
Force PDF header version

### DIFF
--- a/lib/hexapdf/document.rb
+++ b/lib/hexapdf/document.rb
@@ -623,6 +623,17 @@ module HexaPDF
       @version = value.to_s
     end
 
+    def pdf_header_version
+      @pdf_header_version
+    end
+
+    # The are certain cases in which we want to use a certain PDF version.
+    # For example Mustang project requires version 1.7
+    def pdf_header_version=(value)
+      raise ArgumentError, "PDF version must follow format M.N" unless value.to_s.match?(/\A\d\.\d\z/)
+      @pdf_header_version = value.to_s
+    end
+
     # Returns +true+ if the document is encrypted.
     def encrypted?
       !trailer[:Encrypt].nil?

--- a/lib/hexapdf/writer.rb
+++ b/lib/hexapdf/writer.rb
@@ -126,7 +126,7 @@ module HexaPDF
     #
     # See: PDF2.0 s7.5.2
     def write_file_header
-      @io << "%PDF-#{@document.version}\n%\xCF\xEC\xFF\xE8\xD7\xCB\xCD\n"
+      @io << "%PDF-#{@document.pdf_header_version || @document.version}\n%\xCF\xEC\xFF\xE8\xD7\xCB\xCD\n"
     end
 
     # Moves all modified objects into the current revision to avoid invalid references and such.

--- a/test/hexapdf/test_writer.rb
+++ b/test/hexapdf/test_writer.rb
@@ -148,6 +148,15 @@ describe HexaPDF::Writer do
       doc.encrypt(owner_password: 'test')
       assert_raises(HexaPDF::Error) { doc.write('notused', incremental: true) }
     end
+
+    it 'uses pdf_header_version if provided regardless of document version' do
+      doc = HexaPDF::Document.new(io: @std_input_io)
+      doc.version = '2.0'
+      doc.pdf_header_version = '1.7'
+      output_io = StringIO.new
+      HexaPDF::Writer.write(doc, output_io, incremental: true)
+      assert_match(/^%PDF-1.7/, output_io.string)
+    end
   end
 
   it "moves modified objects into the last revision" do


### PR DESCRIPTION
The are certain cases in which we want to use a certain PDF version.
For example Mustang project requires version 1.7 .