### PR TITLE
Fix NoMethodError when page tree Kids contains non-page objects

### DIFF
--- a/lib/hexapdf/type/page_tree_node.rb
+++ b/lib/hexapdf/type/page_tree_node.rb
@@ -103,10 +103,12 @@ module HexaPDF
             else
               index -= 1
             end
-          elsif index < kid[:Count]
-            return kid.page(index)
-          else
-            index -= kid[:Count]
+          elsif kid.type == :Pages
+            if index < kid[:Count]
+              return kid.page(index)
+            else
+              index -= kid[:Count]
+            end
           end
         end
       end
@@ -241,7 +243,7 @@ module HexaPDF
         self[:Kids].each do |kid|
           if kid.type == :Page
             yield(kid)
-          else
+          elsif kid.type == :Pages
             kid.each_page(&block)
           end
         end

--- a/test/hexapdf/type/test_page_tree_node.rb
+++ b/test/hexapdf/type/test_page_tree_node.rb
@@ -77,6 +77,13 @@ describe HexaPDF::Type::PageTreeNode do
       assert_nil(@root.page(20))
       assert_nil(@root.page(-20))
     end
+
+    it "skips invalid objects in the Kids array" do
+      font = @doc.add({Type: :Font, Subtype: :Type1, BaseFont: :Helvetica})
+      @root[:Kids].insert(1, font)
+      assert_equal(@pages[0], @root.page(0))
+      assert_equal(@pages[5], @root.page(5))
+    end
   end
 
   describe "insert_page" do
@@ -280,6 +287,12 @@ describe HexaPDF::Type::PageTreeNode do
     end
 
     it "iterates over a multilevel page tree" do
+      assert_equal(@pages, @root.each_page.to_a)
+    end
+
+    it "skips invalid objects in the Kids array" do
+      font = @doc.add({Type: :Font, Subtype: :Type1, BaseFont: :Helvetica})
+      @kid12[:Kids] << font
       assert_equal(@pages, @root.each_page.to_a)
     end
   end


### PR DESCRIPTION
Fixes #427.

## Problem

When a corrupt PDF has an object that is neither a `:Page` nor a `:Pages` node inside the page tree's `/Kids` array (e.g. a `FontType1` object), `#each_page` raises `NoMethodError` and `#page` raises `NoMethodError`/`TypeError` because they unconditionally call page-tree methods on anything that isn't `:Page`.

## Fix

Add an explicit `elsif kid.type == :Pages` guard in both `#each_page` and `#page`, so non-page/non-pages objects are silently skipped. This is consistent with how `perform_validation` already handles invalid entries in the page tree (removing them with an auto-correct message).

### Design choice: skip vs raise

We considered raising a `HexaPDF::Error` instead of silently skipping, which would make the problem visible to callers. We went with skipping because:

- `perform_validation` already silently removes these entries (with `auto_correct: true`), so skipping is consistent with the library's existing behavior for this exact scenario.
- Callers iterating pages on an unvalidated document likely want best-effort results from the valid pages rather than an exception from one corrupt entry.

That said, if you'd prefer raising (or a hybrid like logging a warning), happy to adjust.

## Tests

Added two tests: one for `#each_page` and one for `#page`, each inserting a Font object into the Kids array and verifying no error is raised and valid pages are still returned correctly.