### PR TITLE
fix: extract text from TrueType fonts with no ToUnicode CMap and no Encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## HEAD
+
+### Fixed
+
+* [HexaPDF::Type::FontTrueType] to extract text from TrueType fonts that have
+  no ToUnicode CMap and no Encoding entry by reading the encoding from the
+  embedded font's cmap table (Unicode cmaps yield a direct code-point lookup;
+  a Mac Roman cmap falls back to MacRomanEncoding)
+
+
 ## 1.9.1 - 2026-06-09
 
 ### Fixed

--- a/lib/hexapdf/type/font_true_type.rb
+++ b/lib/hexapdf/type/font_true_type.rb
@@ -63,6 +63,54 @@ module HexaPDF
 
       private
 
+      # Returns an encoding backed by the cmap table of the embedded TrueType font.
+      #
+      # If the font has a Unicode cmap (platform 0 or Microsoft/BMP), a +BuiltInUnicodeEncoding+
+      # that maps character codes directly to Unicode via that cmap is returned. If the font only
+      # has a Mac Roman cmap (platform 1, encoding 0), +MacRomanEncoding+ is returned since Mac
+      # Roman character codes map to that encoding.
+      #
+      # Raises HexaPDF::Error if the font is not embedded or has no usable cmap table.
+      #
+      # See: PDF2.0 s9.6.6.4
+      def encoding_from_font
+        ff = font_file
+        raise HexaPDF::Error, "No encoding and TrueType font '#{self[:BaseFont]}' is not embedded" unless ff
+        cmap = HexaPDF::Font::TrueType::Font.new(StringIO.new(ff.stream))[:cmap]
+        raise HexaPDF::Error, "No cmap table in embedded TrueType font '#{self[:BaseFont]}'" unless cmap
+        if (table = cmap.preferred_table)
+          BuiltInUnicodeEncoding.new(table)
+        elsif cmap.tables.any? {|t| t.platform_id == 1 && t.encoding_id == 0 }
+          HexaPDF::Font::Encoding.for_name(:MacRomanEncoding)
+        else
+          raise HexaPDF::Error, "No usable cmap in embedded TrueType font '#{self[:BaseFont]}'"
+        end
+      end
+
+      # An encoding backed directly by a Unicode cmap subtable of an embedded TrueType font.
+      #
+      # Used when the font dictionary has no +Encoding+ entry and the embedded font provides a
+      # Unicode cmap (platform 0 or Microsoft BMP). Character codes in the content stream are
+      # looked up in the cmap as Unicode code points; the resolved glyph ID is then reverse-mapped
+      # back to a code point and returned as a UTF-8 character.
+      class BuiltInUnicodeEncoding < HexaPDF::Font::Encoding::Base
+
+        def initialize(cmap_table) #:nodoc:
+          super()
+          @cmap = cmap_table
+        end
+
+        # Returns the Unicode character for +code+, or +nil+ if no mapping exists.
+        def unicode(code)
+          gid = @cmap[code]
+          return nil if !gid || gid.zero?
+          cp = @cmap.gid_to_code(gid)
+          cp ? +'' << cp : nil
+        end
+
+      end
+      private_constant :BuiltInUnicodeEncoding
+
       def perform_validation
         std_font = FontType1::StandardFonts.standard_font?(self[:BaseFont])
         super(ignore_missing_font_fields: std_font)

--- a/test/hexapdf/type/test_font_true_type.rb
+++ b/test/hexapdf/type/test_font_true_type.rb
@@ -35,6 +35,72 @@ describe HexaPDF::Type::FontTrueType do
     end
   end
 
+  describe "encoding" do
+    before do
+      @font.delete(:Encoding)
+      @font[:FontDescriptor][:FontFile2] = @doc.add({}, stream: ubuntu_font_data)
+    end
+
+    it "returns an encoding backed by the embedded font's Unicode cmap" do
+      enc = @font.encoding
+      assert_equal("A", enc.unicode(65))
+      assert_nil(enc.unicode(0))  # U+0000 not mapped in Ubuntu-Title.ttf
+    end
+
+    it "returns nil for a code mapping to glyph 0 (notdef)" do
+      @font[:FontDescriptor][:FontFile2] = @doc.add({}, stream: build_minimal_ttf(0, 3))
+      enc = @font.encoding
+      assert_nil(enc.unicode(0))    # glyph_id=0 -> nil
+      assert_equal("A", enc.unicode(65))
+    end
+
+    it "returns MacRomanEncoding when only a Mac Roman cmap is available" do
+      @font[:FontDescriptor][:FontFile2] = @doc.add({}, stream: build_minimal_ttf(1, 0))
+      assert_equal(HexaPDF::Font::Encoding.for_name(:MacRomanEncoding), @font.encoding)
+    end
+
+    it "fails if the font is not embedded" do
+      @font[:FontDescriptor].delete(:FontFile2)
+      assert_raises(HexaPDF::Error) { @font.encoding }
+    end
+
+    it "fails if no usable cmap is found in the embedded font" do
+      @font[:FontDescriptor][:FontFile2] = @doc.add({}, stream: build_minimal_ttf(3, 4))
+      assert_raises(HexaPDF::Error) { @font.encoding }
+    end
+
+    it "fails if the embedded font has no cmap table" do
+      @font[:FontDescriptor][:FontFile2] = @doc.add({}, stream: build_minimal_ttf_no_cmap)
+      assert_raises(HexaPDF::Error) { @font.encoding }
+    end
+
+    private
+
+    def ubuntu_font_data
+      File.binread(File.join(TEST_DATA_DIR, "fonts", "Ubuntu-Title.ttf"))
+    end
+
+    # Builds a minimal TTF binary containing a single format-0 cmap subtable.
+    # Code 65 maps to glyph 1, all other codes map to glyph 0.
+    def build_minimal_ttf(platform_id, encoding_id)
+      glyph_ids = Array.new(256, 0)
+      glyph_ids[65] = 1
+      subtable = [0, 262, 0].pack("n3") + glyph_ids.pack("C256")
+      cmap_data = [0, 1].pack("n2") +
+                  [platform_id, encoding_id, 12].pack("n2N") +
+                  subtable
+      cmap_offset = 28
+      "\x00\x01\x00\x00".b + [1, 16, 0, 0].pack("n4") +
+        "cmap".b + [0, cmap_offset, cmap_data.bytesize].pack("N3") +
+        cmap_data
+    end
+
+    # Builds a minimal TTF binary with no tables (simulates a font missing the cmap table).
+    def build_minimal_ttf_no_cmap
+      "\x00\x01\x00\x00".b + [0, 0, 0, 0].pack("n4")
+    end
+  end
+
   describe "validation" do
     it "ignores some missing fields if the font name is one of the standard PDF fonts" do
       @font[:BaseFont] = :'Arial,Bold'


### PR DESCRIPTION
## Problem

`HexaPDF::Type::FontTrueType` inherits `encoding_from_font` from `FontSimple`
but does not implement it. When a TrueType font dictionary has no `ToUnicode`
CMap and no `Encoding` entry — a pattern common in PDFs exported from Word,
Pages, and similar tools — text extraction raises a `NotImplementedError`:

```
FontSimple#encoding_from_font: Needs to be implemented in subclass
```

Fixes #430.

## Root cause

`FontSimple#to_utf8` tries three sources in order:
1. `to_unicode_cmap.to_unicode(code)` — absent or incomplete in these PDFs
2. `(encoding.unicode(code) rescue nil)` — calls `encoding`, which calls
   `encoding_from_font` when `self[:Encoding]` is `nil`
3. `missing_unicode_mapping(code)` — the error fallback

For `FontTrueType`, step 2 raised instead of returning a usable encoding.

`FontType1` has the same hook and implements it by reading the embedded
font's data (see `FontType1#encoding_from_font`). This PR does the same
for TrueType fonts.

## Fix

Implement `encoding_from_font` in `FontTrueType` (PDF 2.0 s9.6.6.4):

- Parse the embedded TrueType font's SFNT `cmap` table using the
  existing `HexaPDF::Font::TrueType::Font` infrastructure.
- If a Unicode cmap is available (platform 0 or Microsoft BMP, per
  `Cmap#preferred_table`): return a new `BuiltInUnicodeEncoding` that
  maps character codes through the cmap's glyph-ID reverse lookup.
- If only a Mac Roman cmap is present (platform 1, encoding 0): return
  `MacRomanEncoding`, since Mac Roman character codes map directly to
  that encoding.
- Otherwise raise `HexaPDF::Error`.

`BuiltInUnicodeEncoding` is a minimal `Font::Encoding::Base` subclass
that overrides `unicode(code)` to do a direct cmap lookup instead of
going through a glyph-name table. It is declared `private_constant` since
it is an implementation detail.

## Notes

- When a `ToUnicode` CMap is **partially** present, `to_utf8` uses it
  for codes that are mapped and falls back to `encoding_from_font` for
  the rest. The fallback produces best-effort output; the encoding may
  not match the font's actual code assignment for uncommon codes.
- No existing tests were changed; the three new test cases use the
  existing `Ubuntu-Title.ttf` fixture plus two minimal synthetic TTF
  binaries that exercise the Mac Roman and error paths.
- I have read the [contribution guide](https://hexapdf.gettalong.org/contributing.html)
  and have sent a signed CLA to t_leitner@gmx.at.