### PR TITLE
fix: inherit ParseError from HexaPDF::Error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## HEAD
+
+### Fixed
+
+* [HexaPDF::Type::AcroForm::JavaScriptActions] ParseError to inherit from
+  HexaPDF::Error instead of StandardError
+
+
 ## 1.9.1 - 2026-06-09
 
 ### Fixed

--- a/lib/hexapdf/type/acro_form/java_script_actions.rb
+++ b/lib/hexapdf/type/acro_form/java_script_actions.rb
@@ -82,7 +82,7 @@ module HexaPDF
         class SimplifiedFieldNotationParser
 
           # Raised if there was an error during parsing.
-          class ParseError < StandardError; end
+          class ParseError < HexaPDF::Error; end
 
           # Creates a new instance for the given AcroForm +form+ instance and simplified field
           # notation string +sfn_string+.


### PR DESCRIPTION
`SimplifiedFieldNotationParser::ParseError` currently inherits from `StandardError`, which means it escapes `rescue HexaPDF::Error` — inconsistent with every other exception the library raises.

One-line fix to inherit from `HexaPDF::Error` instead. `hexapdf/error` is already required at the top of the file.